### PR TITLE
chore(1.1.8): build for 1.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Bug Fixes
 
-* Fixed credit card paid status to "processing" when confirmed ([94fc6a7d64baf521cb75cd82abab78b4255d6cb2](https://github.com/cloudwalk/infinitepay-woocommerce-plugin/pull/20/commits/94fc6a7d64baf521cb75cd82abab78b4255d6cb2))
+* Updated order status to "processing" when payment is confirmed ([94fc6a7d64baf521cb75cd82abab78b4255d6cb2](https://github.com/cloudwalk/infinitepay-woocommerce-plugin/pull/20/commits/94fc6a7d64baf521cb75cd82abab78b4255d6cb2))
 
 ## [1.1.0](https://github.com/cloudwalk/infinitepay-woocommerce-plugin/compare/v1.0.0...v1.1.0) (2022-04-25)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.1.8](https://github.com/cloudwalk/infinitepay-woocommerce-plugin/compare/v1.0.0...v1.1.8) (2022-06-29)
+
+### Bug Fixes
+
+* Fixed credit card paid status to "processing" when confirmed ([94fc6a7d64baf521cb75cd82abab78b4255d6cb2](https://github.com/cloudwalk/infinitepay-woocommerce-plugin/pull/20/commits/94fc6a7d64baf521cb75cd82abab78b4255d6cb2))
+
 ## [1.1.0](https://github.com/cloudwalk/infinitepay-woocommerce-plugin/compare/v1.0.0...v1.1.0) (2022-04-25)
 
 

--- a/includes/class-wc-wooinfinitepay-constants.php
+++ b/includes/class-wc-wooinfinitepay-constants.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WC_InfinitePay_Constants {
 
-	const VERSION = '1.1.7';
+	const VERSION = '1.1.8';
 	const MIN_PHP = 5.6;
 	const API_IP_BASE_URL = 'https://api.infinitepay.io';
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce-infinitepay",
 	"title": "woocommerce-infinitepay",
 	"license": "GPL-3.0-or-later",
-	"version": "1.1.7",
+	"version": "1.1.8",
 	"description": "woocommerce-infinitepay",
 	"author": {
 		"name": "InfnitePay",

--- a/readme.txt
+++ b/readme.txt
@@ -51,7 +51,7 @@ If you installed it correctly, you will see it in your list of "Installed Plugin
 == Changelog ==
 - 1.1.8 (2022/06/29) -
 * Bug fixes
-    - Fixed credit card paid status to "processing" when confirmed
+    - Updated order status to "processing" when payment is confirmed
 
 = 1.1.7 (2022/06/24) =
 * Bug fixes

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, infinitepay, woocommerce, payments
 Requires at least: 5.7
 Tested up to: 6.0
 Requires PHP: 7.0
-Stable tag: 1.1.7
+Stable tag: 1.1.8
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -49,6 +49,10 @@ Done! It will be in the "Installed Plugins" section and from there you can activ
 If you installed it correctly, you will see it in your list of "Installed Plugins" on the WordPress work area. Please enable it and input your api key on the specified field.
 
 == Changelog ==
+- 1.1.8 (2022/06/29) -
+* Bug fixes
+    - Fixed credit card paid status to "processing" when confirmed
+
 = 1.1.7 (2022/06/24) =
 * Bug fixes
     - Wrong number when using plugins that change order amount

--- a/woocommerce-infinitepay.php
+++ b/woocommerce-infinitepay.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: InfinitePay for WooCommerce
  * Description: Configure the payment options and accept payments with cards.
- * Version: 1.1.7
+ * Version: 1.1.8
  * Author: Infinite Pay
  * Author URI: https://infinitepay.io/
  * Text Domain: infinitepay-woocommerce


### PR DESCRIPTION
Release for version 1.1.8

- 1.1.8 (2022/06/29) -
* Bug fixes
    - Fixed credit card paid status to "processing" when confirmed