### PR TITLE
removing opcache_reset() from plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.1.10](https://github.com/cloudwalk/infinitepay-woocommerce-plugin/compare/v1.0.9...v1.1.10) (2022-08-08)
+
 ## [1.1.9](https://github.com/cloudwalk/infinitepay-woocommerce-plugin/compare/v1.0.8...v1.1.9) (2022-08-08)
 
 ## [1.1.8](https://github.com/cloudwalk/infinitepay-woocommerce-plugin/compare/v1.0.0...v1.1.8) (2022-06-29)

--- a/includes/class-wc-wooinfinitepay-constants.php
+++ b/includes/class-wc-wooinfinitepay-constants.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class WC_InfinitePay_Constants {
 
-	const VERSION = '1.1.9';
+	const VERSION = '1.1.10';
 	const MIN_PHP = 5.6;
 	const API_IP_BASE_URL = 'https://api.infinitepay.io';
 

--- a/includes/class-wc-wooinfinitepay-init.php
+++ b/includes/class-wc-wooinfinitepay-init.php
@@ -9,7 +9,7 @@
  *  @package InfinitePay
  */
 
-opcache_reset();
+
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce-infinitepay",
 	"title": "woocommerce-infinitepay",
 	"license": "GPL-3.0-or-later",
-	"version": "1.1.9",
+	"version": "1.1.10",
 	"description": "woocommerce-infinitepay",
 	"author": {
 		"name": "InfnitePay",

--- a/readme.txt
+++ b/readme.txt
@@ -51,7 +51,7 @@ If you installed it correctly, you will see it in your list of "Installed Plugin
 == Changelog ==
 - 1.1.10 (2022/08/10) -
 * Bug fixes
-    - Removing opcache from plugin
+    - Fix cache setting for unsupported PHP versions
 
 - 1.1.9 (2022/08/08) -
 * Bug fixes

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ecommerce, infinitepay, woocommerce, payments
 Requires at least: 5.7
 Tested up to: 6.0
 Requires PHP: 7.0
-Stable tag: 1.1.9
+Stable tag: 1.1.10
 License: GPLv3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -49,6 +49,10 @@ Done! It will be in the "Installed Plugins" section and from there you can activ
 If you installed it correctly, you will see it in your list of "Installed Plugins" on the WordPress work area. Please enable it and input your api key on the specified field.
 
 == Changelog ==
+- 1.1.10 (2022/08/10) -
+* Bug fixes
+    - Removing opcache from plugin
+
 - 1.1.9 (2022/08/08) -
 * Bug fixes
     - Displaying the total amount in the installment field

--- a/woocommerce-infinitepay.php
+++ b/woocommerce-infinitepay.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: InfinitePay for WooCommerce
  * Description: Configure the payment options and accept payments with cards.
- * Version: 1.1.9
+ * Version: 1.1.10
  * Author: Infinite Pay
  * Author URI: https://infinitepay.io/
  * Text Domain: infinitepay-woocommerce


### PR DESCRIPTION
This is a hotfix for removing a unnecessary code from plugin