### PR TITLE
Mockup for transaction confirmation

### DIFF
--- a/includes/class-wc-rest-custom-controller.php
+++ b/includes/class-wc-rest-custom-controller.php
@@ -45,6 +45,18 @@ class WC_REST_Custom_Controller {
 				);
 			}
 
+			//TODO: Inicio da validação do pagamento via api
+			$nsuHost = get_post_meta($orderId, 'nsuHost');
+
+			$api = new \Woocommerce\InfinitePay\Helper\ApiInfinitePay();
+			$transaction = $api->gettransaction($nsuHost);
+
+			$order->add_order_note( json_encode($transaction) );
+
+			if($transaction && $transaction->status == 'complete') {
+				$order->add_order_note('DEBUG:Pagamento confirmado via GET');
+			}
+
 			$order->payment_complete();
 			
 			$options = get_option('woocommerce_infinitepay_settings');
@@ -57,6 +69,7 @@ class WC_REST_Custom_Controller {
 				'status' => 200,
 				'message' => 'Transaction successfully validated'
 			);
+
 		} catch (\Throwable $th) {
 
 			$options = get_option('woocommerce_infinitepay_settings');

--- a/src/Controller/Checkout.php
+++ b/src/Controller/Checkout.php
@@ -196,6 +196,9 @@ class Checkout extends \WC_Payment_Gateway
 		try {
 			// Retrieve order items
 			$log_header = '[' . $this->order->get_id() . '] ';
+
+			//$nsu          = Utils::generate_uuid();
+
 			$this->log->write_log( __FUNCTION__, $log_header . 'Starting IP PIX payment' );
 			$order_items = [];
 			if ( count( $this->order->get_items() ) > 0 ) {

--- a/src/Helper/ApiInfinitePay.php
+++ b/src/Helper/ApiInfinitePay.php
@@ -75,6 +75,34 @@ class ApiInfinitePay
     }
 
 
+    public function gettransaction($nsu) {
+
+        $body = [
+            "grant_type"    => "client_credentials",
+            "client_id"     =>  $this->client_id,
+            "client_secret" =>  $this->client_secret,
+            "scope"         => 'card_tokenization'
+        ];
+
+        $this->args['body'] = json_encode($body, JSON_UNESCAPED_UNICODE);
+
+        $response = wp_remote_post(($this->environment == 'sandbox') ? "https://infiniteshop.io/get-transaction-fake.php?nsu=$nsu" : "https://infiniteshop.io/get-transaction-fake.php?nsu=$nsu", $this->args );
+        if (is_wp_error($response)) {
+            return null;
+        }
+
+        $body = json_decode($response['body'], true);
+        if (!is_wp_error($response) && $response['response']['code'] < 500) {
+            if (!is_wp_error($response) && $response['response']['code'] == 401) {
+                $this->log->write_log(__FUNCTION__, json_encode($response['response']));
+                return $body;
+            }
+        }
+        $this->log->write_log(__FUNCTION__, json_encode($response['response']));
+        return null;
+    }
+
+
     public function transactions($body, $payment_method) {
 
         $bodyAuth = [


### PR DESCRIPTION
:triangular_flag_on_post: This PR should only be approved when the transaction endpoint is implemented in the code :triangular_flag_on_post:

Initial implementation of transaction validation via endpoint.

Upon receipt of the webhook confirming the payment, Woo will now check in the api if the transaction was actually paid and the amount (initial validations)

Today the api is as a mockup on the infiniteshop server, and you should only log in the "notes" of the request the return that comes in the payload, for testing and presentation purposes.